### PR TITLE
Fix sidekiq restart retry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ Berksfile.lock
 Gemfile.lock
 bin/*
 .bundle/*
-
+.idea

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,5 +5,6 @@ default[:sidekiq][:logfile] = "config/sidekiq.yml"
 default[:sidekiq][:pids_dir] = "tmp/pids"
 default[:sidekiq][:log_dir] = "log"
 default[:sidekiq][:sidekiq_conf] = "/etc/sidekiq.conf"
+# Upstart kill timeout will be set to 1 second more than sidekiq deadline timeout.
 default[:sidekiq][:deadline_timeout] = 60
 default[:sidekiq][:user] = "root"

--- a/templates/default/sidekiq.upstart.erb
+++ b/templates/default/sidekiq.upstart.erb
@@ -23,6 +23,10 @@ stop on (stopping sidekiq-manager or runlevel [06])
 respawn
 respawn limit 3 30
 
+<% unless @deadline_timeout.nil? %>
+kill timeout <%= @deadline_timeout.to_i+1 %>
+<% end %>
+
 # TERM and USR1 are sent by sidekiqctl when stopping sidekiq.  Without declaring these as normal exit codes, it just respawns.
 normal exit 0 TERM USR1 137 143 KILL
 


### PR DESCRIPTION
What
----------------------
Set upstart kill timeout to 1 second more than sidekiq deadline timeout instead of default 5 seconds.

http://upstart.ubuntu.com/cookbook/#kill-timeout
https://github.com/mperham/sidekiq/wiki/Deployment#overview

Why
----------------------
It breaks sidekiq restart retry feature.


